### PR TITLE
Add basic Hono member API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
 # tradingviewhook_backend
+
+This project provides a basic member management REST API using **Hono** running on **Cloudflare Workers**.
+
+## Features
+
+- CRUD routes under `/members` storing data in memory
+- Written in TypeScript using the Hono framework
+- Can be deployed using Cloudflare Workers and `wrangler`
+
+## Getting Started
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Start a development server (requires `wrangler`):
+
+   ```bash
+   npx wrangler dev
+   ```
+
+3. The API will be available at `http://localhost:8787` with routes:
+   - `GET /members` – list members
+   - `POST /members` – create member `{ "name": "A", "email": "a@example.com" }`
+   - `GET /members/:id` – get member by id
+   - `PUT /members/:id` – update member
+   - `DELETE /members/:id` – delete member
+
+Data is stored in memory and will reset when the worker restarts. For persistent storage consider using Cloudflare D1 or KV.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "tradingviewhook_backend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tradingviewhook_backend",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "hono": "^4.7.11"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.7.11.tgz",
+      "integrity": "sha512-rv0JMwC0KALbbmwJDEnxvQCeJh+xbS3KEWW5PC9cMJ08Ur9xgatI0HmtgYZfOdOSOeYsp5LO2cOhdI8cLEbDEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "tradingviewhook_backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "hono": "^4.7.11"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,57 @@
+import { Hono } from 'hono'
+
+interface Member {
+  id: number
+  name: string
+  email: string
+}
+
+const app = new Hono()
+
+let members: Member[] = []
+let idCounter = 1
+
+app.get('/members', (c) => c.json(members))
+
+app.post('/members', async (c) => {
+  const body: Partial<Member> = await c.req.json()
+  if (!body.name || !body.email) {
+    return c.json({ error: 'name and email required' }, 400)
+  }
+  const member: Member = { id: idCounter++, name: body.name, email: body.email }
+  members.push(member)
+  return c.json(member, 201)
+})
+
+app.get('/members/:id', (c) => {
+  const id = Number(c.req.param('id'))
+  const member = members.find(m => m.id === id)
+  if (!member) {
+    return c.json({ error: 'member not found' }, 404)
+  }
+  return c.json(member)
+})
+
+app.put('/members/:id', async (c) => {
+  const id = Number(c.req.param('id'))
+  const member = members.find(m => m.id === id)
+  if (!member) {
+    return c.json({ error: 'member not found' }, 404)
+  }
+  const body: Partial<Member> = await c.req.json()
+  member.name = body.name ?? member.name
+  member.email = body.email ?? member.email
+  return c.json(member)
+})
+
+app.delete('/members/:id', (c) => {
+  const id = Number(c.req.param('id'))
+  const index = members.findIndex(m => m.id === id)
+  if (index === -1) {
+    return c.json({ error: 'member not found' }, 404)
+  }
+  members.splice(index, 1)
+  return c.body(null, 204)
+})
+
+export default app

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,9 @@
+name = "tradingviewhook-backend"
+main = "src/index.ts"
+compatibility_date = "2023-01-01"
+
+[build]
+command = "npm install"
+
+[dev]
+port = 8787


### PR DESCRIPTION
## Summary
- setup Hono project for Cloudflare Workers
- implement a REST API for members in `src/index.ts`
- add `wrangler.toml` for worker configuration
- document how to run the project
- ignore `node_modules`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844df4131f88327b9a9e3f48d79e7e1