### PR TITLE
Add Cloudflare Worker example with Hono

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,24 @@ This project provides a basic member management REST API using **Fastify** runni
    - `DELETE /members/:id` – delete member
 
 Data is stored in memory and will reset when the server restarts. For persistent storage consider using a real database.
+
+## Cloudflare Worker Version (Bun + Hono)
+
+This repository also includes a Cloudflare Worker powered by **Hono**. The entry
+point is `src/worker.ts` and it can be run locally using **wrangler** with the
+help of **Bun**.
+
+1. Install the dependency:
+
+   ```bash
+   bun add hono
+   ```
+
+2. Start the worker locally:
+
+   ```bash
+   bunx wrangler dev
+   ```
+
+The worker exposes the same CRUD routes under `/members` and runs on
+`http://localhost:8787` by default.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "fastify": "^5.3.3"
+    "fastify": "^5.3.3",
+    "hono": "^4.7.11"
+  },
+  "devDependencies": {
+    "wrangler": "^3.38.0"
   }
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,60 @@
+import { Hono } from 'hono'
+
+const app = new Hono()
+
+interface Member {
+  id: number
+  name: string
+  email: string
+}
+
+const members: Member[] = []
+let idCounter = 1
+
+app.get('/members', (c) => {
+  return c.json(members)
+})
+
+app.post('/members', async (c) => {
+  const body = await c.req.json().catch(() => ({})) as Partial<Member>
+  if (!body.name || !body.email) {
+    return c.json({ error: 'name and email required' }, 400)
+  }
+  const member: Member = { id: idCounter++, name: body.name, email: body.email }
+  members.push(member)
+  return c.json(member, 201)
+})
+
+app.get('/members/:id', (c) => {
+  const id = Number(c.req.param('id'))
+  const member = members.find(m => m.id === id)
+  if (!member) {
+    return c.json({ error: 'member not found' }, 404)
+  }
+  return c.json(member)
+})
+
+app.put('/members/:id', async (c) => {
+  const id = Number(c.req.param('id'))
+  const member = members.find(m => m.id === id)
+  if (!member) {
+    return c.json({ error: 'member not found' }, 404)
+  }
+  const body = await c.req.json().catch(() => ({})) as Partial<Member>
+  member.name = body.name ?? member.name
+  member.email = body.email ?? member.email
+  return c.json(member)
+})
+
+app.delete('/members/:id', (c) => {
+  const id = Number(c.req.param('id'))
+  const index = members.findIndex(m => m.id === id)
+  if (index === -1) {
+    return c.json({ error: 'member not found' }, 404)
+  }
+  members.splice(index, 1)
+  return c.body(null, 204)
+})
+
+export default app
+export const fetch = app.fetch

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "types": ["@cloudflare/workers-types"]
+  }
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,3 @@
+name = "hono-api"
+main = "src/worker.ts"
+compatibility_date = "2024-04-01"


### PR DESCRIPTION
## Summary
- use Hono to provide the same CRUD API as a Cloudflare Worker
- add wrangler configuration and TypeScript settings
- document how to run the worker with Bun

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68464480d6a88327b7db5027e37579b0